### PR TITLE
Update meta_model.py

### DIFF
--- a/emat/model/meta_model.py
+++ b/emat/model/meta_model.py
@@ -319,7 +319,7 @@ class MetaModel:
             self.regression.set_params(random_state=random_state)
 
         if suppress_converge_warnings:
-            from sklearn.gaussian_process.gpr import ConvergenceWarning
+            from sklearn.exceptions import ConvergenceWarning
             import warnings
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=ConvergenceWarning)


### PR DESCRIPTION
In the old version, it will generate an error message by using the "suppress_converge_warnings=True" feature in "create_metamodel" function. The problem comes from "from sklearn.gaussian_process.gpr import ConvergenceWarning" command. It can be solved by replaced with "from sklearn.exceptions import ConvergenceWarning".